### PR TITLE
Add en_term to Area type.

### DIFF
--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -1,7 +1,7 @@
 import { CSSProperties, MouseEvent, ReactNode, useRef } from 'react'
 import Tooltip, { TooltipMethods } from './Tooltip'
-import '../../styles.css'
 import { RegionType } from '../areas/regions'
+import '../../styles.css'
 
 export type Area = {
   id: string
@@ -9,6 +9,7 @@ export type Area = {
   en_name: string
   display_name: string
   d: string
+  en_term?: string
   region?: Omit<RegionType, 'd'>
   code?: string
   altD?: string


### PR DESCRIPTION
### Proposed changes

Added `en_term` to `Area` to improve Intellisense and type safety.

### How to test

1. Verify that `en_term` is a type on the `IslandType` and `DenmarkType`.