### PR TITLE
Memoize components and refactor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,35 @@ All props that accept a function as an argument have the same type in that compo
 
 Different components have different types for the area parameter. The `Regions` component, for example, exports a `RegionsType` that can be used in the same way as shown above. See "API - Types" for the full reference of area types.
 
+## Performance
+
+If you want to make sure that each version of the map rerenders as few times as possible to improve performance, make sure to memoize the objects and functions that you pass as props with [`useMemo`](https://react.dev/reference/react/useMemo) and [`useCallback`](https://react.dev/reference/react/useCallback). Each component is only shallowly memoized. Below is an example of memoizing the `customizeAreas` and `style` props.
+
+```jsx
+const App = () => {
+  const [state, setState] = useState(0)
+
+  const style = useMemo(() => ({ color: 'red' }), [])
+
+  const customizeAreas = useCallback(() => {
+    return {
+      style: {
+        fill: 'red'
+      }
+    }
+  }, [])
+
+  return (
+    <>
+      <button onClick={() => setState(state + 1)}></button>
+      <Municipalities customizeAreas={customizeAreas} style={style} />
+    </>
+  )
+}
+```
+
+The result is that the map won't be rerendered when updating the unrelated state.
+
 ## API
 
 ### Components

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -337,6 +337,37 @@ describe('Map', () => {
       })
     })
 
+    describe('customizeAreas', () => {
+      it('should render given areas with the given style and className', () => {
+        const customizeAreas = (municipality: MunicipalityType) => {
+          if (municipality.name === 'langeland') {
+            return {
+              className: 'red-municipality',
+              style: {
+                fill: 'red'
+              }
+            }
+          }
+        }
+
+        const { container } = render(<Municipalities customizeAreas={customizeAreas} />)
+
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
+
+        const differentMunicipality = container.querySelector('#koebenhavn')
+        if (!differentMunicipality) throw new Error('Municipality not found')
+
+        // @ts-expect-error - the style property is not defined on the HTMLElement type
+        expect(municipality.style.fill).toBe('red')
+        expect(municipality.classList).toContain('red-municipality')
+
+        // @ts-expect-error - the style property is not defined on the HTMLElement type
+        expect(differentMunicipality.style.fill).not.toBe('red')
+        expect(differentMunicipality.classList).not.toContain('red-municipality')
+      })
+    })
+
     describe('viewBox', () => {
       it('should render with the given viewbox', () => {
         const { container } = render(

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -1,12 +1,48 @@
 import { useCallback, useMemo, useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 // the municipalities component is used to test the generic map component
+import Constituencies from '../areas/constituencies/Constituencies'
+import Denmark from '../areas/denmark/Denmark'
+import Islands from '../areas/islands/Islands'
 import Municipalities from '../areas/municipalities/Municipalities'
+import Regions from '../areas/regions/Regions'
 import { MunicipalityType } from '../areas/municipalities'
 import { test } from '../../utils'
 
 describe('Map', () => {
   afterEach(() => jest.restoreAllMocks())
+
+  describe('should render with', () => {
+    it('constituencies', () => {
+      const { container } = render(<Constituencies />)
+      const constituency = container.querySelector('#sydjyllands')
+      expect(constituency).toBeTruthy()
+    })
+
+    it('denmark', () => {
+      const { container } = render(<Denmark />)
+      const denmark = container.querySelector('#danmark')
+      expect(denmark).toBeTruthy()
+    })
+
+    it('islands', () => {
+      const { container } = render(<Islands />)
+      const island = container.querySelector('#fyn')
+      expect(island).toBeTruthy()
+    })
+
+    it('municipalities', () => {
+      const { container } = render(<Municipalities />)
+      const municipality = container.querySelector('#langeland')
+      expect(municipality).toBeTruthy()
+    })
+
+    it('regions', () => {
+      const { container } = render(<Regions />)
+      const region = container.querySelector('#nordjylland')
+      expect(region).toBeTruthy()
+    })
+  })
 
   describe('should rerender', () => {
     it('upon prop update', async () => {

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -1,288 +1,430 @@
+import { useCallback, useMemo, useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 // the municipalities component is used to test the generic map component
 import Municipalities from '../areas/municipalities/Municipalities'
 import { MunicipalityType } from '../areas/municipalities'
+import { test } from '../../utils'
 
 describe('Map', () => {
-  it('should render successfully', () => {
-    render(<Municipalities />)
+  afterEach(() => jest.restoreAllMocks())
+
+  describe('should rerender', () => {
+    it('upon prop update', async () => {
+      const Test = () => {
+        const [state, setState] = useState(0)
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        const style = useMemo(() => ({ color: 'red' }), [state])
+
+        return (
+          <>
+            <button onClick={() => setState(state + 1)}></button>
+            <Municipalities style={style} />
+          </>
+        )
+      }
+
+      const { container } = render(<Test />)
+
+      const button = container.getElementsByTagName('button')
+      const spy = jest.spyOn(test, 'rerenders')
+
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
   })
 
-  it('should render with the given className', () => {
-    const { container } = render(<Municipalities className="test" />)
+  describe('should not rerender', () => {
+    it('with no props', async () => {
+      const Test = () => {
+        const [state, setState] = useState(0)
 
-    const style = container.querySelector('#react-denmark-map-svg')?.classList
+        return (
+          <>
+            <button onClick={() => setState(state + 1)}></button>
+            <Municipalities />
+          </>
+        )
+      }
 
-    expect(style).toContain('test')
+      const { container } = render(<Test />)
+
+      const button = container.getElementsByTagName('button')
+      const spy = jest.spyOn(test, 'rerenders')
+
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('with memoized function prop', async () => {
+      const Test = () => {
+        const [state, setState] = useState(0)
+
+        const customizeAreas = useCallback(() => {
+          return {
+            style: {
+              fill: 'red'
+            }
+          }
+        }, [])
+
+        return (
+          <>
+            <button onClick={() => setState(state + 1)}></button>
+            <Municipalities customizeAreas={customizeAreas} />
+          </>
+        )
+      }
+
+      const { container } = render(<Test />)
+
+      const button = container.getElementsByTagName('button')
+      const spy = jest.spyOn(test, 'rerenders')
+
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('with memoized object prop', async () => {
+      const Test = () => {
+        const [state, setState] = useState(0)
+
+        const style = useMemo(() => ({ color: 'red' }), [])
+
+        return (
+          <>
+            <button onClick={() => setState(state + 1)}></button>
+            <Municipalities style={style} />
+          </>
+        )
+      }
+
+      const { container } = render(<Test />)
+
+      const button = container.getElementsByTagName('button')
+      const spy = jest.spyOn(test, 'rerenders')
+
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+      fireEvent.click(button[0])
+
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
   })
 
-  it('should render with the given style', () => {
-    const { container } = render(<Municipalities style={{ backgroundColor: 'red' }} />)
+  describe('with no props', () => {
+    it('should render the municipality name in the tooltip when hovering', () => {
+      const { container } = render(<Municipalities />)
 
-    // @ts-expect-error - the style property is not defined on the HTMLElement type
-    const style = container.querySelector('#react-denmark-map-svg')?.style.backgroundColor
+      const municipality = container.querySelector('#langeland')
 
-    expect(style).toBe('red')
+      if (!municipality) throw new Error('Municipality not found')
+
+      fireEvent.mouseEnter(municipality)
+
+      const tooltip = container.querySelector('#react-denmark-map-tooltip')
+
+      expect(tooltip?.textContent).toBe('Langeland')
+    })
   })
 
-  it('should render with the given width', () => {
-    const { container } = render(<Municipalities style={{ width: '700px' }} />)
+  describe('with prop', () => {
+    describe('className', () => {
+      it('should render with the given className', () => {
+        const { container } = render(<Municipalities className="test" />)
 
-    // @ts-expect-error - the style property is not defined on the HTMLElement type
-    const width = container.querySelector('#react-denmark-map-svg')?.style.width
+        const style = container.querySelector('#react-denmark-map-svg')?.classList
 
-    expect(width).toBe('700px')
-  })
-
-  it('should render with the given color', () => {
-    const { container } = render(<Municipalities color="blue" />)
-
-    const color = container.querySelector('svg')?.style.fill
-
-    expect(color).toBe('blue')
-  })
-
-  it('should render the municipality name in the tooltip when hovering', () => {
-    const { container } = render(<Municipalities />)
-
-    const municipality = container.querySelector('#langeland')
-
-    if (!municipality) throw new Error('Municipality not found')
-
-    fireEvent.mouseEnter(municipality)
-
-    const tooltip = container.querySelector('#react-denmark-map-tooltip')
-
-    expect(tooltip?.textContent).toBe('Langeland')
-  })
-
-  it('should not render the tooltip when showTooltip is false', () => {
-    const { container } = render(<Municipalities showTooltip={false} />)
-
-    const municipality = container.querySelector('#langeland')
-
-    if (!municipality) throw new Error('Municipality not found')
-
-    fireEvent.mouseEnter(municipality)
-
-    const tooltip = container.querySelector('#react-denmark-map-tooltip')
-    expect(tooltip).toBeNull()
-  })
-
-  it('should render the custom tooltip when hovering', () => {
-    const customTooltip = (municipality: MunicipalityType) => <div>{municipality.display_name}</div>
-
-    const { container } = render(<Municipalities customTooltip={customTooltip} />)
-
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
-
-    fireEvent.mouseEnter(municipality)
-
-    const defaultTooltip = container.querySelector('#react-denmark-map-tooltip')
-    expect(defaultTooltip).toBeFalsy()
-
-    const customTooltipElement = container.querySelector('#react-denmark-map-tooltip-wrapper > div')
-    expect(customTooltipElement?.textContent).toBe('Langeland')
-  })
-
-  it('should call the onClick function when clicking a municipality', () => {
-    const onClick = jest.fn()
-
-    const { container } = render(<Municipalities onClick={onClick} />)
-
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
-
-    fireEvent.click(municipality)
-
-    expect(onClick).toHaveBeenCalled()
-    expect(onClick).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'langeland',
-        name: 'langeland',
-        en_name: 'langeland',
-        display_name: 'Langeland',
-        code: '482'
+        expect(style).toContain('test')
       })
-    )
-  })
+    })
 
-  it('should call the onHover callback when hovering', () => {
-    const onHover = jest.fn()
+    describe('style', () => {
+      it('should render with the given style', () => {
+        const { container } = render(<Municipalities style={{ width: '700px' }} />)
 
-    const { container } = render(<Municipalities onHover={onHover} />)
+        // @ts-expect-error - the style property is not defined on the HTMLElement type
+        const width = container.querySelector('#react-denmark-map-svg')?.style.width
 
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
-
-    fireEvent.mouseOver(municipality)
-
-    expect(onHover).toHaveBeenCalled()
-    expect(onHover).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'langeland',
-        name: 'langeland',
-        en_name: 'langeland',
-        display_name: 'Langeland',
-        code: '482'
+        expect(width).toBe('700px')
       })
-    )
-  })
+    })
 
-  it('should not apply the hoverable className when hoverable prop is false', () => {
-    const { container } = render(<Municipalities hoverable={false} />)
+    describe('color', () => {
+      it('should render with the given color', () => {
+        const { container } = render(<Municipalities color="blue" />)
 
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
+        const color = container.querySelector('svg')?.style.fill
 
-    expect(municipality.classList).not.toContain('react-denmark-map-hoverable')
-  })
-
-  it('should apply the clickable className when clickable prop is true', () => {
-    const { container } = render(<Municipalities clickable />)
-
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
-
-    expect(municipality.classList).toContain('react-denmark-map-clickable')
-  })
-
-  it('should apply the clickable className when clickable prop is undefined and onClick is set', () => {
-    const onClick = jest.fn()
-
-    const { container } = render(<Municipalities onClick={onClick} />)
-
-    const municipality = container.querySelector('#langeland')
-
-    if (!municipality) throw new Error('Municipality not found')
-
-    expect(municipality.classList).toContain('react-denmark-map-clickable')
-  })
-
-  it('should call the onMouseEnter callback when entering a municipality', () => {
-    const onMouseEnter = jest.fn()
-
-    const { container } = render(<Municipalities onMouseEnter={onMouseEnter} />)
-
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
-
-    fireEvent.mouseEnter(municipality)
-
-    expect(onMouseEnter).toHaveBeenCalled()
-    expect(onMouseEnter).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'langeland',
-        name: 'langeland',
-        en_name: 'langeland',
-        display_name: 'Langeland',
-        code: '482'
+        expect(color).toBe('blue')
       })
-    )
-  })
+    })
 
-  it('should call the onMouseLeave callback when leaving a municipality', () => {
-    const onMouseLeave = jest.fn()
+    describe('showTooltip', () => {
+      it('should not render the tooltip when showTooltip is false', () => {
+        const { container } = render(<Municipalities showTooltip={false} />)
 
-    const { container } = render(<Municipalities onMouseLeave={onMouseLeave} />)
+        const municipality = container.querySelector('#langeland')
 
-    const municipality = container.querySelector('#langeland')
-    if (!municipality) throw new Error('Municipality not found')
+        if (!municipality) throw new Error('Municipality not found')
 
-    fireEvent.mouseLeave(municipality)
+        fireEvent.mouseEnter(municipality)
 
-    expect(onMouseLeave).toHaveBeenCalled()
-    expect(onMouseLeave).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'langeland',
-        name: 'langeland',
-        en_name: 'langeland',
-        display_name: 'Langeland',
-        code: '482'
+        const tooltip = container.querySelector('#react-denmark-map-tooltip')
+        expect(tooltip).toBeNull()
       })
-    )
-  })
+    })
 
-  it('should render with the given viewbox', () => {
-    const { container } = render(
-      <Municipalities viewBox={{ left: 0, top: 0, width: 7000, height: 8000 }} />
-    )
+    describe('customTooltip', () => {
+      it('should render the custom tooltip when hovering', () => {
+        const customTooltip = (municipality: MunicipalityType) => (
+          <div>{municipality.display_name}</div>
+        )
 
-    const viewbox = container.querySelector('svg')?.getAttribute('viewBox')
+        const { container } = render(<Municipalities customTooltip={customTooltip} />)
 
-    expect(viewbox).toBe('0 0 7000 8000')
-  })
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
 
-  it('should render with the default viewBox width when no viewbox is provided', () => {
-    const { container } = render(<Municipalities />)
+        fireEvent.mouseEnter(municipality)
 
-    const viewbox = container.querySelector('svg')?.getAttribute('viewBox')
+        const defaultTooltip = container.querySelector('#react-denmark-map-tooltip')
+        expect(defaultTooltip).toBeFalsy()
 
-    expect(viewbox).toBe('0 0 10116 12289') // default width and height from the municipalities component
-  })
+        const customTooltipElement = container.querySelector(
+          '#react-denmark-map-tooltip-wrapper > div'
+        )
+        expect(customTooltipElement?.textContent).toBe('Langeland')
+      })
+    })
 
-  it('should round viewbox width and height to nearest integer', () => {
-    const { container } = render(
-      <Municipalities
-        viewBox={{
-          width: 1000.499,
-          height: 1000.5
-        }}
-      />
-    )
+    describe('onClick', () => {
+      it('should call the onClick function when clicking a municipality', () => {
+        const onClick = jest.fn()
 
-    const viewbox = container.querySelector('svg')?.getAttribute('viewBox')
+        const { container } = render(<Municipalities onClick={onClick} />)
 
-    expect(viewbox).toBe('0 0 1000 1001')
-  })
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
 
-  it('should exclude an area when the exclude prop is set to filter an area', () => {
-    const { container } = render(
-      <Municipalities filterAreas={(municipality) => !(municipality.name === 'københavn')} />
-    )
+        fireEvent.click(municipality)
 
-    const municipality = container.querySelector('#koebenhavn')
-    expect(municipality).toBeNull()
-  })
+        expect(onClick).toHaveBeenCalled()
+        expect(onClick).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'langeland',
+            name: 'langeland',
+            en_name: 'langeland',
+            display_name: 'Langeland',
+            code: '482'
+          })
+        )
+      })
 
-  it('should exclude all other areas when the exclude prop is set to a specific area', () => {
-    const { container } = render(
-      <Municipalities filterAreas={(municipality) => municipality.region.name === 'nordjylland'} />
-    )
+      it('should apply the clickable className when clickable prop is undefined', () => {
+        const onClick = jest.fn()
 
-    const municipality1 = container.querySelector('#koebenhavn')
-    const municipality2 = container.querySelector('#odense')
-    const municipality3 = container.querySelector('#faxe')
-    expect(municipality1).toBeNull()
-    expect(municipality2).toBeNull()
-    expect(municipality3).toBeNull()
-  })
+        const { container } = render(<Municipalities onClick={onClick} />)
 
-  it('should render different `d` when alt positions prop is set', () => {
-    const mapDefault = render(<Municipalities />)
-    const mapAlt = render(
-      <Municipalities bornholmAltPostition anholtAltPosition laesoeAltPosition />
-    )
+        const municipality = container.querySelector('#langeland')
 
-    const bornholmDefault = mapDefault.container.querySelector('#bornholm')?.getAttribute('d')
-    const anholtDefault = mapDefault.container.querySelector('#norddjurs')?.getAttribute('d')
-    const laesoeDefault = mapDefault.container.querySelector('#laesoe')?.getAttribute('d')
+        if (!municipality) throw new Error('Municipality not found')
 
-    const bornholmAlt = mapAlt.container.querySelector('#bornholm')?.getAttribute('d')
-    const anholtAlt = mapAlt.container.querySelector('#norddjurs')?.getAttribute('d')
-    const laesoeAlt = mapAlt.container.querySelector('#laesoe')?.getAttribute('d')
+        expect(municipality.classList).toContain('react-denmark-map-clickable')
+      })
+    })
 
-    expect(bornholmDefault).toBeTruthy()
-    expect(bornholmAlt).toBeTruthy()
-    expect(bornholmDefault).not.toBe(bornholmAlt)
+    describe('onHover', () => {
+      it('should call the onHover callback when hovering', () => {
+        const onHover = jest.fn()
 
-    expect(anholtDefault).toBeTruthy()
-    expect(anholtAlt).toBeTruthy()
-    expect(laesoeAlt).not.toBe(anholtAlt)
+        const { container } = render(<Municipalities onHover={onHover} />)
 
-    expect(laesoeDefault).toBeTruthy()
-    expect(laesoeAlt).toBeTruthy()
-    expect(laesoeDefault).not.toBe(laesoeAlt)
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
+
+        fireEvent.mouseOver(municipality)
+
+        expect(onHover).toHaveBeenCalled()
+        expect(onHover).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'langeland',
+            name: 'langeland',
+            en_name: 'langeland',
+            display_name: 'Langeland',
+            code: '482'
+          })
+        )
+      })
+    })
+
+    describe('hoverable', () => {
+      it('should not apply the hoverable className when hoverable prop is false', () => {
+        const { container } = render(<Municipalities hoverable={false} />)
+
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
+
+        expect(municipality.classList).not.toContain('react-denmark-map-hoverable')
+      })
+    })
+
+    describe('clickable', () => {
+      it('should apply the clickable className when clickable prop is true', () => {
+        const { container } = render(<Municipalities clickable />)
+
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
+
+        expect(municipality.classList).toContain('react-denmark-map-clickable')
+      })
+    })
+
+    describe('onMouseEnter', () => {
+      it('should call the onMouseEnter callback when entering a municipality', () => {
+        const onMouseEnter = jest.fn()
+
+        const { container } = render(<Municipalities onMouseEnter={onMouseEnter} />)
+
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
+
+        fireEvent.mouseEnter(municipality)
+
+        expect(onMouseEnter).toHaveBeenCalled()
+        expect(onMouseEnter).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'langeland',
+            name: 'langeland',
+            en_name: 'langeland',
+            display_name: 'Langeland',
+            code: '482'
+          })
+        )
+      })
+    })
+
+    describe('onMouseLeave', () => {
+      it('should call the onMouseLeave callback when leaving a municipality', () => {
+        const onMouseLeave = jest.fn()
+
+        const { container } = render(<Municipalities onMouseLeave={onMouseLeave} />)
+
+        const municipality = container.querySelector('#langeland')
+        if (!municipality) throw new Error('Municipality not found')
+
+        fireEvent.mouseLeave(municipality)
+
+        expect(onMouseLeave).toHaveBeenCalled()
+        expect(onMouseLeave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'langeland',
+            name: 'langeland',
+            en_name: 'langeland',
+            display_name: 'Langeland',
+            code: '482'
+          })
+        )
+      })
+    })
+
+    describe('viewBox', () => {
+      it('should render with the given viewbox', () => {
+        const { container } = render(
+          <Municipalities viewBox={{ left: 0, top: 0, width: 7000, height: 8000 }} />
+        )
+
+        const viewbox = container.querySelector('svg')?.getAttribute('viewBox')
+
+        expect(viewbox).toBe('0 0 7000 8000')
+      })
+
+      it('should render with the default viewBox width when no viewbox is provided', () => {
+        const { container } = render(<Municipalities />)
+
+        const viewbox = container.querySelector('svg')?.getAttribute('viewBox')
+
+        expect(viewbox).toBe('0 0 10116 12289') // default width and height from the municipalities component
+      })
+
+      it('should round viewbox width and height to nearest integer', () => {
+        const { container } = render(
+          <Municipalities
+            viewBox={{
+              width: 1000.499,
+              height: 1000.5
+            }}
+          />
+        )
+
+        const viewbox = container.querySelector('svg')?.getAttribute('viewBox')
+
+        expect(viewbox).toBe('0 0 1000 1001')
+      })
+    })
+
+    describe('filterAreas', () => {
+      it('should exclude an area when the exclude prop is set to filter an area', () => {
+        const { container } = render(
+          <Municipalities filterAreas={(municipality) => !(municipality.name === 'københavn')} />
+        )
+
+        const municipality = container.querySelector('#koebenhavn')
+        expect(municipality).toBeNull()
+      })
+
+      it('should exclude all other areas when the exclude prop is set to a specific area', () => {
+        const { container } = render(
+          <Municipalities
+            filterAreas={(municipality) => municipality.region.name === 'nordjylland'}
+          />
+        )
+
+        const municipality1 = container.querySelector('#koebenhavn')
+        const municipality2 = container.querySelector('#odense')
+        const municipality3 = container.querySelector('#faxe')
+        expect(municipality1).toBeNull()
+        expect(municipality2).toBeNull()
+        expect(municipality3).toBeNull()
+      })
+    })
+
+    describe('altPositions', () => {
+      it('should render different `d` when alt positions prop is set', () => {
+        const mapDefault = render(<Municipalities />)
+        const mapAlt = render(
+          <Municipalities bornholmAltPostition anholtAltPosition laesoeAltPosition />
+        )
+
+        const bornholmDefault = mapDefault.container.querySelector('#bornholm')?.getAttribute('d')
+        const anholtDefault = mapDefault.container.querySelector('#norddjurs')?.getAttribute('d')
+        const laesoeDefault = mapDefault.container.querySelector('#laesoe')?.getAttribute('d')
+
+        const bornholmAlt = mapAlt.container.querySelector('#bornholm')?.getAttribute('d')
+        const anholtAlt = mapAlt.container.querySelector('#norddjurs')?.getAttribute('d')
+        const laesoeAlt = mapAlt.container.querySelector('#laesoe')?.getAttribute('d')
+
+        expect(bornholmDefault).toBeTruthy()
+        expect(bornholmAlt).toBeTruthy()
+        expect(bornholmDefault).not.toBe(bornholmAlt)
+
+        expect(anholtDefault).toBeTruthy()
+        expect(anholtAlt).toBeTruthy()
+        expect(laesoeAlt).not.toBe(anholtAlt)
+
+        expect(laesoeDefault).toBeTruthy()
+        expect(laesoeAlt).toBeTruthy()
+        expect(laesoeDefault).not.toBe(laesoeAlt)
+      })
+    })
   })
 })

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -1,6 +1,7 @@
-import { CSSProperties, MouseEvent, ReactNode, useRef } from 'react'
+import { CSSProperties, MouseEvent, ReactNode, memo, useRef } from 'react'
 import Tooltip, { TooltipMethods } from './Tooltip'
 import { RegionType } from '../areas/regions'
+import { test } from '../../utils'
 import '../../styles.css'
 
 export type Area = {
@@ -59,7 +60,9 @@ const defaultProps: MapProps<Area> = {
   hoverable: true
 }
 
-export default function Map<Type extends Area>(props: PrivateMapProps<Type>) {
+function Map<Type extends Area>(props: PrivateMapProps<Type>) {
+  test.rerenders()
+
   const tooltip = useRef<TooltipMethods>()
 
   const handleClick = (event: MouseEvent<SVGPathElement>) => {
@@ -193,3 +196,6 @@ export default function Map<Type extends Area>(props: PrivateMapProps<Type>) {
 }
 
 Map.defaultProps = defaultProps
+
+// @ts-expect-error Default props cause the type to be incorrect. Remove this line when fixed.
+export default memo(Map) as typeof Map

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -197,5 +197,5 @@ function Map<Type extends Area>(props: PrivateMapProps<Type>) {
 
 Map.defaultProps = defaultProps
 
-// @ts-expect-error Default props cause the type to be incorrect. Remove this line when fixed.
+// @ts-expect-error Default props cause the type to be incorrect. Remove this line when we switch to default parameters.
 export default memo(Map) as typeof Map

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,0 +1,6 @@
+/** Object with methods for testing purposes. */
+export const test = {
+  /** Function for measuring the number of times a component rerenders.
+   * Can be combined with a spy function to create automated rerendering tests. */
+  rerenders: () => {}
+}


### PR DESCRIPTION
### Proposed changes

Memoized components to reduce rerenders and (maybe) improve performance. Extended the documentation with a section on performance. Also added tests for testing rerendering and refactored the existing tests. Finally, added a test for the `customizeAreas` prop and tests for verifying successful rendering of each version of the map.

### How to test

1. Verify that the tests don't fail.
2. Make sure that the section "Performance" makes sense.