### PR TITLE
Zooming and panning functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ Instead of municipalities, these areas could also be each region or island, depe
 
 ### Styling
 
+#### Positioning
+
+It's strongly recommended that you wrap the map in an element and position that according to your needs. Applying a max width and a margin will center the map and preserve it's dimensions across screen sizes.
+
+```jsx
+<div style={{ maxWidth: '600px', margin: '0 auto' }}>
+  <Municipalities />
+</div>
+```
+
+#### Appearance
+
 The exported components also support a number of different ways of styling the map:
 
 ```jsx
@@ -217,9 +229,7 @@ These props are:
 
 - `className` is a string which is applied directly to the SVG element.
 - `style` is an object of CSS properties which is applied directly to the SVG element.
-- `color` is the default color applied to each area of the map. Essentially, this is the default color of the map. It's overwritten by styles returned by the `customizeAreas` function if the function returns a color for that area. Keep in mind that you can apply the `fill` style in the `style` object and it will have the same effect.
-
-For positioning, it is, in many cases, easier to wrap the map in an element and position that according to your needs.
+- `color` is the default color applied to each area of the map.
 
 In addition to the props mentioned above, the `clickable` and `hoverable` props are booleans used to toggle hover styles on each `<path>` element / area. They are purely decorational.
 

--- a/apps/demo/components/examples/ConstituenciesExample.tsx
+++ b/apps/demo/components/examples/ConstituenciesExample.tsx
@@ -10,6 +10,8 @@ export default function ConstituenciesExample() {
   }
 
   return (
-    <Constituencies customizeAreas={customizeAreas} className="p-2 sm:p-8 md:w-[750px] mx-auto" />
+    <div className="max-w-2xl mx-auto">
+      <Constituencies customizeAreas={customizeAreas} className="p-2 sm:p-8" />
+    </div>
   )
 }

--- a/apps/demo/components/examples/DenmarkExample.tsx
+++ b/apps/demo/components/examples/DenmarkExample.tsx
@@ -2,11 +2,8 @@ import { Denmark } from 'react-denmark-map'
 
 export default function DenmarkExample() {
   return (
-    <Denmark
-      color="#c00"
-      hoverable={false}
-      showTooltip={false}
-      className="p-2 sm:p-8 md:w-[750px] mx-auto"
-    />
+    <div className="max-w-2xl mx-auto">
+      <Denmark color="#c00" hoverable={false} showTooltip={false} className="p-2 sm:p-8" />
+    </div>
   )
 }

--- a/apps/demo/components/examples/IslandsExample.tsx
+++ b/apps/demo/components/examples/IslandsExample.tsx
@@ -15,11 +15,13 @@ export default function IslandsExample() {
   }
 
   return (
-    <Islands
-      customizeAreas={customizeIslands}
-      onHover={(island) => setHoveredIsland(island.id)}
-      className="p-2 sm:p-8 md:w-[750px] mx-auto"
-      hoverable={false}
-    />
+    <div className="max-w-2xl mx-auto">
+      <Islands
+        customizeAreas={customizeIslands}
+        onHover={(island) => setHoveredIsland(island.id)}
+        className="p-2 sm:p-8"
+        hoverable={false}
+      />
+    </div>
   )
 }

--- a/apps/demo/components/examples/MunicipalitiesExample.tsx
+++ b/apps/demo/components/examples/MunicipalitiesExample.tsx
@@ -27,11 +27,13 @@ export default function MunicipalitiesExample() {
   }
 
   return (
-    <Municipalities
-      className="p-2 sm:p-8 md:w-[750px] mx-auto"
-      customTooltip={customTooltip}
-      customizeAreas={customizeMunicipalities}
-    />
+    <div className="max-w-2xl mx-auto">
+      <Municipalities
+        className="p-2 sm:p-8"
+        customTooltip={customTooltip}
+        customizeAreas={customizeMunicipalities}
+      />
+    </div>
   )
 }
 

--- a/apps/demo/components/examples/MunicipalitiesRegionsExample.tsx
+++ b/apps/demo/components/examples/MunicipalitiesRegionsExample.tsx
@@ -44,7 +44,7 @@ export default function MunicipalitiesRegionsExample() {
     <div className="relative">
       {selectedRegion && (
         <button
-          className="absolute left-4 md:top-10 md:left-20 text-5xl hover:opacity-60 opacity-80 bg-gray-300 rounded px-2 py-1"
+          className="absolute left-4 md:top-10 md:left-20 text-5xl hover:opacity-60 opacity-80 bg-gray-300 rounded px-2 py-1 z-20"
           onClick={() => setSelectedRegion(null)}
         >
           &larr;

--- a/apps/demo/components/examples/MunicipalitiesRegionsExample.tsx
+++ b/apps/demo/components/examples/MunicipalitiesRegionsExample.tsx
@@ -50,20 +50,19 @@ export default function MunicipalitiesRegionsExample() {
           &larr;
         </button>
       )}
-      {selectedRegion ? (
-        <Municipalities
-          customizeAreas={customizeAreas}
-          viewBox={regionViewboxes[selectedRegion.name]}
-          filterAreas={(municipality) => municipality.region.id === selectedRegion.id}
-          bornholmAltPostition
-          className="p-2 sm:p-8 md:w-[750px] mx-auto"
-        />
-      ) : (
-        <Regions
-          onClick={(region) => setSelectedRegion(region)}
-          className="p-2 sm:p-8 md:w-[750px] mx-auto"
-        />
-      )}
+      <div className="max-w-2xl mx-auto">
+        {selectedRegion ? (
+          <Municipalities
+            customizeAreas={customizeAreas}
+            viewBox={regionViewboxes[selectedRegion.name]}
+            filterAreas={(municipality) => municipality.region.id === selectedRegion.id}
+            bornholmAltPostition
+            className="p-2 sm:p-8"
+          />
+        ) : (
+          <Regions onClick={(region) => setSelectedRegion(region)} className="p-2 sm:p-8" />
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/demo/components/examples/RegionsExample.tsx
+++ b/apps/demo/components/examples/RegionsExample.tsx
@@ -10,10 +10,12 @@ export default function RegionsExample() {
   }
 
   return (
-    <Regions
-      onClick={handleClick}
-      onHover={handleHover}
-      className="p-2 sm:p-8 md:w-[750px] mx-auto"
-    />
+    <div className="max-w-2xl mx-auto">
+      <Regions
+        onClick={handleClick}
+        onHover={handleHover}
+        className="p-2 sm:p-8 md:w-[750px] mx-auto"
+      />
+    </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17300,6 +17300,19 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.3.0.tgz",
+      "integrity": "sha512-vy1h8aenDzXye+HRqANZaSA8IPHoqOiuDPFBkswoyPUH8uMfsmbeH6gFI4r4BhEJa0xIlcA+FbvhidRWKGUrOg==",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -20457,6 +20470,9 @@
       "name": "react-denmark-map",
       "version": "1.3.1",
       "license": "MIT",
+      "dependencies": {
+        "react-zoom-pan-pinch": "^3.3.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.18.13",
         "@babel/preset-env": "^7.18.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -84,5 +84,8 @@
     "dist"
   ],
   "types": "dist/index.d.ts",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "react-zoom-pan-pinch": "^3.3.0"
+  }
 }

--- a/packages/core/src/components/areas/constituencies/Constituencies.stories.tsx
+++ b/packages/core/src/components/areas/constituencies/Constituencies.stories.tsx
@@ -1,18 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import Constituencies from './Constituencies'
+import { MapProps } from '../../map/Map'
+import { ConstituencyType } from './data'
 
-const defaultStyle = {
-  maxWidth: '750px',
-  margin: '0 auto'
+const Wrapper = (props: MapProps<ConstituencyType>) => {
+  return (
+    <div style={{ maxWidth: '650px', margin: '0 auto' }}>
+      <Constituencies {...props} />
+    </div>
+  )
 }
 
 const meta = {
   title: 'ReactDenmarkMap/Constituencies',
-  component: Constituencies,
-  args: {
-    style: defaultStyle
-  }
-} satisfies Meta<typeof Constituencies>
+  component: Wrapper,
+  args: {}
+} satisfies Meta<typeof Wrapper>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/packages/core/src/components/areas/denmark/Denmark.stories.tsx
+++ b/packages/core/src/components/areas/denmark/Denmark.stories.tsx
@@ -1,18 +1,21 @@
 import { Meta, StoryObj } from '@storybook/react'
 import Denmark from './Denmark'
+import { MapProps } from '../../map/Map'
+import { DenmarkType } from './data'
 
-const defaultStyle = {
-  maxWidth: '750px',
-  margin: '0 auto'
+const Wrapper = (props: MapProps<DenmarkType>) => {
+  return (
+    <div style={{ maxWidth: '650px', margin: '0 auto' }}>
+      <Denmark {...props} />
+    </div>
+  )
 }
 
 const meta = {
   title: 'ReactDenmarkMap/Denmark',
-  component: Denmark,
-  args: {
-    style: defaultStyle
-  }
-} satisfies Meta<typeof Denmark>
+  component: Wrapper,
+  args: {}
+} satisfies Meta<typeof Wrapper>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/packages/core/src/components/areas/islands/Islands.stories.tsx
+++ b/packages/core/src/components/areas/islands/Islands.stories.tsx
@@ -1,18 +1,21 @@
 import { Meta, StoryObj } from '@storybook/react'
 import Islands from './Islands'
+import { MapProps } from '../../map/Map'
+import { IslandType } from './data'
 
-const defaultStyle = {
-  maxWidth: '750px',
-  margin: '0 auto'
+const Wrapper = (props: MapProps<IslandType>) => {
+  return (
+    <div style={{ maxWidth: '650px', margin: '0 auto' }}>
+      <Islands {...props} />
+    </div>
+  )
 }
 
 const meta = {
   title: 'ReactDenmarkMap/Islands',
-  component: Islands,
-  args: {
-    style: defaultStyle
-  }
-} satisfies Meta<typeof Islands>
+  component: Wrapper,
+  args: {}
+} satisfies Meta<typeof Wrapper>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -27,8 +30,6 @@ export const WithCustomizeIslands: Story = {
           style: { fill: 'green' }
         }
       }
-    },
-    onClick: undefined,
-    style: defaultStyle
+    }
   }
 }

--- a/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
+++ b/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
@@ -3,6 +3,7 @@ import Municipalities from './Municipalities'
 import Regions, { RegionType } from '../regions'
 import { MunicipalityType } from './data'
 import { useState } from 'react'
+import { MapProps } from '../../map/Map'
 
 const mockMunicipalityData: { id: string; average: number }[] = [
   {
@@ -159,18 +160,18 @@ const mockMunicipalityData: { id: string; average: number }[] = [
   }
 ]
 
-const defaultStyle = {
-  maxWidth: '750px',
-  margin: '0 auto'
+const Wrapper = (props: MapProps<MunicipalityType>) => {
+  return (
+    <div style={{ maxWidth: '650px', margin: '0 auto' }}>
+      <Municipalities {...props} />
+    </div>
+  )
 }
 
 const meta = {
   title: 'ReactDenmarkMap/Municipalities',
-  component: Municipalities,
-  args: {
-    style: defaultStyle
-  }
-} satisfies Meta<typeof Municipalities>
+  component: Wrapper
+} satisfies Meta<typeof Wrapper>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -179,7 +180,7 @@ export const Default: Story = {}
 
 export const WithCustomStyle: Story = {
   args: {
-    style: { backgroundColor: 'black', paddingTop: '20px', paddingBottom: '20px', ...defaultStyle },
+    style: { backgroundColor: 'black', paddingTop: '20px', paddingBottom: '20px' },
     color: 'white'
   }
 }
@@ -256,18 +257,24 @@ const MunicipalitiesInRegionsTemplate: StoryFn<typeof Municipalities> = (args) =
 
   if (!selectedRegion) {
     return (
-      <Regions
+      <div
         style={{
-          backgroundColor: '#f0f0f0',
-          ...defaultStyle
+          maxWidth: '650px',
+          margin: '0 auto'
         }}
-        onClick={(region) => setSelectedRegion(region)}
-      />
+      >
+        <Regions
+          style={{
+            backgroundColor: '#f0f0f0'
+          }}
+          onClick={(region) => setSelectedRegion(region)}
+        />
+      </div>
     )
   }
 
   return (
-    <div style={{ backgroundColor: '#f0f0f0', ...defaultStyle }}>
+    <div style={{ backgroundColor: '#f0f0f0', maxWidth: '750px', margin: '0 auto' }}>
       <button onClick={() => setSelectedRegion(null)}>Back</button>
       <Municipalities
         customizeAreas={customizeAreas}

--- a/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
+++ b/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
@@ -162,7 +162,7 @@ const mockMunicipalityData: { id: string; average: number }[] = [
 
 const Wrapper = (props: MapProps<MunicipalityType>) => {
   return (
-    <div style={{ maxWidth: '650px', margin: '0 auto' }}>
+    <div style={{ maxWidth: '600px', margin: '0 auto' }}>
       <Municipalities {...props} />
     </div>
   )

--- a/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
+++ b/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
@@ -361,3 +361,20 @@ export const WithFilterAreas: Story = {
     filterAreas: (municipality) => !(municipality.region.name === 'hovedstaden')
   }
 }
+
+export const WithCustomZoomControls: Story = {
+  args: {
+    CustomZoomControls: ({ onZoomIn, onZoomOut }) => (
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <button onClick={() => onZoomIn()}>+</button>
+        <button onClick={() => onZoomOut()}>–</button>
+      </div>
+    )
+  }
+}
+
+export const NonZoomable: Story = {
+  args: {
+    zoomable: false
+  }
+}

--- a/packages/core/src/components/areas/regions/Regions.stories.tsx
+++ b/packages/core/src/components/areas/regions/Regions.stories.tsx
@@ -1,18 +1,21 @@
 import { Meta, StoryObj } from '@storybook/react'
 import Regions from './Regions'
+import { MapProps } from '../../map/Map'
+import { RegionType } from './data'
 
-const defaultStyle = {
-  maxWidth: '750px',
-  margin: '0 auto'
+const Wrapper = (props: MapProps<RegionType>) => {
+  return (
+    <div style={{ maxWidth: '650px', margin: '0 auto' }}>
+      <Regions {...props} />
+    </div>
+  )
 }
 
 const meta = {
   title: 'ReactDenmarkMap/Regions',
-  component: Regions,
-  args: {
-    style: defaultStyle
-  }
-} satisfies Meta<typeof Regions>
+  component: Wrapper,
+  args: {}
+} satisfies Meta<typeof Wrapper>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -536,5 +536,33 @@ describe('Map', () => {
         expect(zoomControls).toBeFalsy()
       })
     })
+
+    describe('CustomZoomControls', () => {
+      it('should render custom zoom controls when set', () => {
+        const CustomZoomControls = ({
+          onZoomIn,
+          onZoomOut
+        }: {
+          onZoomIn(): void
+          onZoomOut(): void
+        }) => (
+          <div>
+            <button id="zoom-in" onClick={onZoomIn}>
+              Zoom in
+            </button>
+            <button id="zoom-out" onClick={onZoomOut}>
+              Zoom out
+            </button>
+          </div>
+        )
+
+        const { container } = render(<Municipalities CustomZoomControls={CustomZoomControls} />)
+
+        const zoomInButton = container.querySelector('#zoom-in')
+        const zoomOutButton = container.querySelector('#zoom-out')
+
+        if (!zoomInButton || !zoomOutButton) throw new Error('Zoom buttons not found')
+      })
+    })
   })
 })

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -171,6 +171,43 @@ describe('Map', () => {
 
       expect(tooltip?.textContent).toBe('Langeland')
     })
+
+    it('should be able to zoom in and out', async () => {
+      const { container } = render(<Municipalities />)
+
+      const zoomInButton = container.querySelector('.react-denmark-map-zoom-controls > button')
+      const zoomOutButton = container.querySelector(
+        '.react-denmark-map-zoom-controls > button:nth-child(2)'
+      )
+
+      if (!zoomInButton || !zoomOutButton) throw new Error('Zoom buttons not found')
+
+      let zoomPanePrevious = container.querySelector<HTMLElement>('.react-transform-component')
+      let zoomPanePreviousStyle = zoomPanePrevious?.style.transform
+
+      fireEvent.click(zoomInButton)
+
+      // Since zooming has an animation, we must wait for the animation to finish before testing
+      // whether the zoom has triggered. It may cause some flakyness.
+      await new Promise((r) => setTimeout(r, 250))
+
+      expect(
+        container.querySelector<HTMLElement>('.react-transform-component')?.style.transform
+      ).not.toBe(zoomPanePreviousStyle)
+
+      fireEvent.click(zoomOutButton)
+
+      zoomPanePrevious = container.querySelector<HTMLElement>('.react-transform-component')
+      zoomPanePreviousStyle = zoomPanePrevious?.style.transform
+
+      fireEvent.click(zoomInButton)
+
+      await new Promise((r) => setTimeout(r, 250))
+
+      expect(
+        container.querySelector<HTMLElement>('.react-transform-component')?.style.transform
+      ).not.toBe(zoomPanePreviousStyle)
+    })
   })
 
   describe('with prop', () => {
@@ -188,8 +225,7 @@ describe('Map', () => {
       it('should render with the given style', () => {
         const { container } = render(<Municipalities style={{ width: '700px' }} />)
 
-        // @ts-expect-error - the style property is not defined on the HTMLElement type
-        const width = container.querySelector('#react-denmark-map-svg')?.style.width
+        const width = container.querySelector<HTMLElement>('#react-denmark-map-svg')?.style.width
 
         expect(width).toBe('700px')
       })
@@ -388,17 +424,15 @@ describe('Map', () => {
 
         const { container } = render(<Municipalities customizeAreas={customizeAreas} />)
 
-        const municipality = container.querySelector('#langeland')
+        const municipality = container.querySelector<HTMLElement>('#langeland')
         if (!municipality) throw new Error('Municipality not found')
 
-        const differentMunicipality = container.querySelector('#koebenhavn')
+        const differentMunicipality = container.querySelector<HTMLElement>('#koebenhavn')
         if (!differentMunicipality) throw new Error('Municipality not found')
 
-        // @ts-expect-error - the style property is not defined on the HTMLElement type
         expect(municipality.style.fill).toBe('red')
         expect(municipality.classList).toContain('red-municipality')
 
-        // @ts-expect-error - the style property is not defined on the HTMLElement type
         expect(differentMunicipality.style.fill).not.toBe('red')
         expect(differentMunicipality.classList).not.toContain('red-municipality')
       })

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -527,5 +527,14 @@ describe('Map', () => {
         expect(laesoeDefault).not.toBe(laesoeAlt)
       })
     })
+
+    describe('zoomable', () => {
+      it('should not render zoom controls when zoomable prop is false', () => {
+        const { container } = render(<Municipalities zoomable={false} />)
+
+        const zoomControls = container.querySelector('.react-denmark-map-zoom-controls')
+        expect(zoomControls).toBeFalsy()
+      })
+    })
   })
 })

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -538,7 +538,7 @@ describe('Map', () => {
     })
 
     describe('CustomZoomControls', () => {
-      it('should render custom zoom controls when set', () => {
+      it('should render custom zoom controls', () => {
         const CustomZoomControls = ({
           onZoomIn,
           onZoomOut

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties, MouseEvent, ReactNode, memo, useRef } from 'react'
 import Tooltip, { TooltipMethods } from './Tooltip'
+import Zoompane from './Zoompane'
 import { RegionType } from '../areas/regions'
 import { test } from '../../utils'
 import '../../styles.css'
@@ -158,39 +159,45 @@ function Map<Type extends Area>(props: PrivateMapProps<Type>) {
   }
 
   return (
-    <figure id="react-denmark-map">
+    <figure
+      id="react-denmark-map"
+      style={{
+        position: 'relative',
+        maxWidth: '1180px'
+      }}
+    >
       <Tooltip
         show={typeof props.showTooltip === 'undefined' ? true : props.showTooltip}
         areas={props.areas}
         customTooltip={props.customTooltip as (area: Area) => ReactNode}
         ref={tooltip}
       />
-      <svg
-        id="react-denmark-map-svg"
-        version="1.1"
-        viewBox={
-          `${Math.round(props.viewBox?.left ?? 0)} ` +
-          `${Math.round(props.viewBox?.top ?? 0)} ` +
-          `${Math.round(props.viewBox?.width ?? props.defaultViewBoxWidth)} ` +
-          `${Math.round(props.viewBox?.height ?? props.defaultViewBoxHeight)}`
-        }
-        xmlns="http://www.w3.org/2000/svg"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-        xmlSpace="preserve"
-        className={props.className}
-        style={{
-          fill: props.color,
-          display: 'block',
-          maxWidth: '1180px',
-          fillRule: 'evenodd',
-          clipRule: 'evenodd',
-          strokeLinejoin: 'round',
-          strokeMiterlimit: 2,
-          ...props.style
-        }}
-      >
-        <g>{getAreas()}</g>
-      </svg>
+      <Zoompane>
+        <svg
+          id="react-denmark-map-svg"
+          version="1.1"
+          viewBox={
+            `${Math.round(props.viewBox?.left ?? 0)} ` +
+            `${Math.round(props.viewBox?.top ?? 0)} ` +
+            `${Math.round(props.viewBox?.width ?? props.defaultViewBoxWidth)} ` +
+            `${Math.round(props.viewBox?.height ?? props.defaultViewBoxHeight)}`
+          }
+          xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+          xmlSpace="preserve"
+          className={props.className}
+          style={{
+            fill: props.color,
+            fillRule: 'evenodd',
+            clipRule: 'evenodd',
+            strokeLinejoin: 'round',
+            strokeMiterlimit: 2,
+            ...props.style
+          }}
+        >
+          <g>{getAreas()}</g>
+        </svg>
+      </Zoompane>
     </figure>
   )
 }

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -172,7 +172,8 @@ function Map<Type extends Area>(props: PrivateMapProps<Type>) {
       id="react-denmark-map"
       style={{
         position: 'relative',
-        maxWidth: '1180px'
+        maxWidth: '1180px',
+        margin: 0
       }}
     >
       <Tooltip

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -36,6 +36,9 @@ export interface MapProps<Type extends Area> {
   showTooltip?: boolean
   clickable?: boolean
   hoverable?: boolean
+  bornholmAltPostition?: boolean
+  laesoeAltPosition?: boolean
+  anholtAltPosition?: boolean
   /** Controls whether the ability to zoom in and out should be enabled. */
   zoomable?: boolean
   /** Custom zoom control component for controlling zooming in and out.
@@ -44,9 +47,6 @@ export interface MapProps<Type extends Area> {
    * @param onZoomOut Callback for zooming out.
    */
   CustomZoomControls?: ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
-  bornholmAltPostition?: boolean
-  laesoeAltPosition?: boolean
-  anholtAltPosition?: boolean
   customTooltip?: (area: Type) => ReactNode
   onClick?: (area: Type) => void
   onHover?: (area: Type) => void
@@ -170,6 +170,7 @@ function Map<Type extends Area>(props: PrivateMapProps<Type>) {
   return (
     <figure
       id="react-denmark-map"
+      className="react-denmark-map"
       style={{
         position: 'relative',
         maxWidth: '1180px',

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -38,7 +38,7 @@ export interface MapProps<Type extends Area> {
   hoverable?: boolean
   /** Controls whether the ability to zoom in and out should be enabled. */
   zoomable?: boolean
-  /** Custom zoom controls for controlling zooming in and out.
+  /** Custom zoom control component for controlling zooming in and out.
    *
    * @param onZoomIn Callback for zooming in.
    * @param onZoomOut Callback for zooming out.

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, MouseEvent, ReactNode, memo, useRef } from 'react'
+import { CSSProperties, ComponentType, MouseEvent, ReactNode, memo, useRef } from 'react'
 import Tooltip, { TooltipMethods } from './Tooltip'
 import Zoompane from './Zoompane'
 import { RegionType } from '../areas/regions'
@@ -36,6 +36,14 @@ export interface MapProps<Type extends Area> {
   showTooltip?: boolean
   clickable?: boolean
   hoverable?: boolean
+  /** Controls whether the ability to zoom in and out should be enabled. */
+  zoomable?: boolean
+  /** Custom zoom controls for controlling zooming in and out.
+   *
+   * @param onZoomIn Callback for zooming in.
+   * @param onZoomOut Callback for zooming out.
+   */
+  CustomZoomControls?: ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
   bornholmAltPostition?: boolean
   laesoeAltPosition?: boolean
   anholtAltPosition?: boolean
@@ -58,7 +66,8 @@ const defaultProps: MapProps<Area> = {
   style: {},
   color: '#ccc',
   showTooltip: true,
-  hoverable: true
+  hoverable: true,
+  zoomable: true
 }
 
 function Map<Type extends Area>(props: PrivateMapProps<Type>) {
@@ -172,7 +181,7 @@ function Map<Type extends Area>(props: PrivateMapProps<Type>) {
         customTooltip={props.customTooltip as (area: Area) => ReactNode}
         ref={tooltip}
       />
-      <Zoompane>
+      <Zoompane zoomable={props.zoomable as boolean} CustomZoomControls={props.CustomZoomControls}>
         <svg
           id="react-denmark-map-svg"
           version="1.1"

--- a/packages/core/src/components/map/Tooltip.tsx
+++ b/packages/core/src/components/map/Tooltip.tsx
@@ -31,7 +31,8 @@ function Tooltip<Type extends Area>(
     position: 'fixed',
     display: 'block',
     top: 0,
-    left: 0
+    left: 0,
+    zIndex: 1
   })
 
   useImperativeHandle(ref, () => ({

--- a/packages/core/src/components/map/Zoompane.tsx
+++ b/packages/core/src/components/map/Zoompane.tsx
@@ -1,14 +1,18 @@
-import { ReactNode } from 'react'
+import { ComponentType, ReactNode } from 'react'
 import { TransformComponent, TransformWrapper, useControls } from 'react-zoom-pan-pinch'
 
+type CustomZoomControls = ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
+
 type ZoompaneProps = {
+  zoomable: boolean
+  CustomZoomControls?: CustomZoomControls
   children: ReactNode
 }
 
-export default function Zoompane({ children }: ZoompaneProps) {
+export default function Zoompane({ zoomable, CustomZoomControls, children }: ZoompaneProps) {
   return (
-    <TransformWrapper maxScale={4}>
-      <Controls />
+    <TransformWrapper maxScale={zoomable ? 4 : 1}>
+      {zoomable && <Controls CustomZoomControls={CustomZoomControls} />}
       <TransformComponent contentStyle={{ width: '100%' }} wrapperStyle={{ width: '100%' }}>
         {children}
       </TransformComponent>
@@ -16,13 +20,19 @@ export default function Zoompane({ children }: ZoompaneProps) {
   )
 }
 
-function Controls() {
+function Controls({ CustomZoomControls }: { CustomZoomControls?: CustomZoomControls }) {
   const { zoomIn, zoomOut } = useControls()
 
   return (
-    <div className="react-denmark-map-zoom-controls">
-      <button onClick={() => zoomIn()}>+</button>
-      <button onClick={() => zoomOut()}>–</button>
+    <div className="react-denmark-map-zoom-controls-wrapper">
+      {CustomZoomControls ? (
+        <CustomZoomControls onZoomIn={() => zoomIn()} onZoomOut={() => zoomOut()} />
+      ) : (
+        <div className="react-denmark-map-zoom-controls">
+          <button onClick={() => zoomIn()}>+</button>
+          <button onClick={() => zoomOut()}>–</button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/core/src/components/map/Zoompane.tsx
+++ b/packages/core/src/components/map/Zoompane.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react'
+import { TransformComponent, TransformWrapper, useControls } from 'react-zoom-pan-pinch'
+
+type ZoompaneProps = {
+  children: ReactNode
+}
+
+export default function Zoompane({ children }: ZoompaneProps) {
+  return (
+    <TransformWrapper maxScale={4}>
+      <Controls />
+      <TransformComponent contentStyle={{ width: '100%' }} wrapperStyle={{ width: '100%' }}>
+        {children}
+      </TransformComponent>
+    </TransformWrapper>
+  )
+}
+
+function Controls() {
+  const { zoomIn, zoomOut } = useControls()
+
+  return (
+    <div className="react-denmark-map-zoom-controls">
+      <button onClick={() => zoomIn()}>+</button>
+      <button onClick={() => zoomOut()}>–</button>
+    </div>
+  )
+}

--- a/packages/core/src/styles.css
+++ b/packages/core/src/styles.css
@@ -21,15 +21,18 @@
   cursor: pointer;
 }
 
-.react-denmark-map-zoom-controls {
+.react-denmark-map-zoom-controls-wrapper {
+  margin: 8px;
+  z-index: 1;
   position: absolute;
   right: 0;
+}
+
+.react-denmark-map-zoom-controls {
   display: inline-flex;
   flex-direction: column;
-  z-index: 1;
   border: #ededed 1px solid;
   border-radius: 5px;
-  margin: 8px;
   box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
   -webkit-box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);

--- a/packages/core/src/styles.css
+++ b/packages/core/src/styles.css
@@ -1,3 +1,10 @@
+.react-denmark-map {
+  /* "rdm" is an abbreviation for "react-denmark-map". */
+  --rdm-gray: #d3d3d3;
+  --rdm-light-gray: #ededed;
+  --rdm-white: #ffffff;
+}
+
 .react-denmark-map-tooltip {
   font-weight: 500;
   background-color: white;
@@ -31,7 +38,6 @@
 .react-denmark-map-zoom-controls {
   display: inline-flex;
   flex-direction: column;
-  border: #ededed 1px solid;
   border-radius: 5px;
   box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
   -webkit-box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
@@ -41,7 +47,7 @@
 .react-denmark-map-zoom-controls > button {
   outline: none;
   border: 0;
-  background-color: white;
+  background-color: var(--rdm-white);
   padding: 6px 6px 4px;
   cursor: pointer;
   font-size: 16px;
@@ -56,10 +62,10 @@
 }
 
 .react-denmark-map-zoom-controls > button:hover {
-  background-color: #ededed;
+  background-color: var(--rdm-light-gray);
   transition: background-color 0.1s ease-in-out;
 }
 
 .react-denmark-map-zoom-controls > button:active {
-  background-color: lightgray;
+  background-color: var(--rdm-gray);
 }

--- a/packages/core/src/styles.css
+++ b/packages/core/src/styles.css
@@ -20,3 +20,43 @@
   fill-opacity: 70%;
   cursor: pointer;
 }
+
+.react-denmark-map-zoom-controls {
+  position: absolute;
+  right: 0;
+  display: inline-flex;
+  flex-direction: column;
+  z-index: 1;
+  border: #ededed 1px solid;
+  border-radius: 5px;
+  margin: 8px;
+  box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
+  -webkit-box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
+  -moz-box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.3);
+}
+
+.react-denmark-map-zoom-controls > button {
+  outline: none;
+  border: 0;
+  background-color: white;
+  padding: 6px 6px 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.react-denmark-map-zoom-controls > button:first-child {
+  border-radius: 3px 3px 0 0;
+}
+
+.react-denmark-map-zoom-controls > button:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.react-denmark-map-zoom-controls > button:hover {
+  background-color: #ededed;
+  transition: background-color 0.1s ease-in-out;
+}
+
+.react-denmark-map-zoom-controls > button:active {
+  background-color: lightgray;
+}


### PR DESCRIPTION
### Proposed changes

Added the ability to zoom and pan in the map by default. Added two new props to add custom zoom controls and disable zooming.

### How to test

1. Open Storybook and select "Municipalities" > "Default".
2. Verify that zoom controls are visible in the top-right hand corner.
3. Verify that the zoom controls zoom in and out.
4. Verify that you can pan the camera by dragging while zoomed in.
5. Verify that you can select an area and the tooltip will be displayed.
6. Run the tests and verify that the tests don't fail.