### PR TITLE
Rename `CustomZoomControls` to `customZoomControls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ const App = () => {
 
 ### Zooming
 
-The `customZoomControls` prop allows you to customize the default zoom controls.
+The `customZoomControls` prop allows you to pass your own zoom controls.
 
 ```jsx
 import { Municipalities } from 'react-denmark-map'

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ const CustomZoomControls = ({ onZoomIn, onZoomOut }) => (
 )
 
 const App = () => {
-  return <Municipalities CustomZoomControls={CustomZoomControls} />
+  return <Municipalities customZoomControls={CustomZoomControls} />
 }
 ```
 
@@ -275,6 +275,7 @@ Alternatively, you can apply styles via CSS selectors. Some tags are available t
 - `react-denmark-map-svg` is the `svg` element which contains the path of each area.
 - `react-denmark-map` is the top-most `figure` element and the parent of `svg`.
 - `react-denmark-map-tooltip` is the default tooltip `div` element.
+- `react-denmark-map-zoom-controls` is the parent `div` element to the two buttons constituting the default zoom controls.
 
 ## Typescript
 
@@ -347,7 +348,7 @@ React Denmark Map exports several components, each being a map of Denmark with d
 | `laesoeAltPosition`   | Whether to render Læsø slightly closer to Jutland in the `Municipalities` component.                    | boolean                                                                       | false                                          |
 | `anholtAltPosition`   | Whether to render Anholt closer to Jutland in the `Municipalities` component.                           | boolean                                                                       | false                                          |
 | `zoomable`            | Whether you should be able to zoom on the map.                                                          | boolean                                                                       | true                                           |
-| `CustomZoomControls`  | A React component for custom zoom controls.                                                             | ComponentType<{ onZoomIn(): void; onZoomOut(): void }>                        |                                                |
+| `customZoomControls`  | A React component for custom zoom controls.                                                             | ComponentType<{ onZoomIn(): void; onZoomOut(): void }>                        |                                                |
 | `customTooltip`       | A function that returns a custom tooltip.                                                               | (area: AreaType<sup>\*\*\*</sup>) => ReactNode                                |                                                |
 | `customizeAreas`      | A function that is invoked for every area and returns an object to style the area.                      | (area: AreaType) => { className?: string, style? CSSProperties } \| undefined |                                                |
 | `filterAreas`         | A function that is invoked for every area that avoids rendering the area if the function returns false. | (area: AreaType) => boolean                                                   |                                                |

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ const App = () => {
 
 ### Zooming
 
-The `CustomZoomControls` prop allows you to customize the default zoom controls.
+The `customZoomControls` prop allows you to customize the default zoom controls.
 
 ```jsx
 import { Municipalities } from 'react-denmark-map'

--- a/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
+++ b/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
@@ -374,10 +374,10 @@ export const WithFilterAreas: Story = {
 
 export const WithCustomZoomControls: Story = {
   args: {
-    CustomZoomControls: ({ onZoomIn, onZoomOut }) => (
+    customZoomControls: ({ onZoomIn, onZoomOut }) => (
       <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <button onClick={() => onZoomIn()}>+</button>
-        <button onClick={() => onZoomOut()}>–</button>
+        <button onClick={onZoomIn}>+</button>
+        <button onClick={onZoomOut}>–</button>
       </div>
     )
   }

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -529,7 +529,7 @@ describe('Map', () => {
           </div>
         )
 
-        const { container } = render(<Municipalities CustomZoomControls={CustomZoomControls} />)
+        const { container } = render(<Municipalities customZoomControls={CustomZoomControls} />)
 
         const zoomInButton = container.querySelector('#zoom-in')
         const zoomOutButton = container.querySelector('#zoom-out')

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -510,7 +510,7 @@ describe('Map', () => {
       })
     })
 
-    describe('CustomZoomControls', () => {
+    describe('customZoomControls', () => {
       it('should render custom zoom controls', () => {
         const CustomZoomControls = ({
           onZoomIn,

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -49,7 +49,7 @@ export interface MapProps<Type extends Area> {
    * @param onZoomIn Callback for zooming in.
    * @param onZoomOut Callback for zooming out.
    */
-  CustomZoomControls?: ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
+  customZoomControls?: ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
   customTooltip?: (area: Type) => ReactNode
   onClick?: (area: Type) => void
   onHover?: (area: Type) => void
@@ -77,7 +77,7 @@ const Map = <Type extends Area>(props: PrivateMapProps<Type>) => {
     laesoeAltPosition,
     anholtAltPosition,
     viewBox,
-    CustomZoomControls,
+    customZoomControls,
     className,
     onMouseEnter,
     onMouseLeave,
@@ -179,7 +179,7 @@ const Map = <Type extends Area>(props: PrivateMapProps<Type>) => {
         customTooltip={customTooltip as (area: Area) => ReactNode}
         ref={tooltip}
       />
-      <Zoompane zoomable={zoomable as boolean} CustomZoomControls={CustomZoomControls}>
+      <Zoompane zoomable={zoomable as boolean} customZoomControls={customZoomControls}>
         <svg
           id="react-denmark-map-svg"
           viewBox={

--- a/packages/core/src/components/map/Zoompane.tsx
+++ b/packages/core/src/components/map/Zoompane.tsx
@@ -5,14 +5,14 @@ type CustomZoomControls = ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
 
 type ZoompaneProps = {
   zoomable: boolean
-  CustomZoomControls?: CustomZoomControls
+  customZoomControls?: CustomZoomControls
   children: ReactNode
 }
 
-export default function Zoompane({ zoomable, CustomZoomControls, children }: ZoompaneProps) {
+export default function Zoompane({ zoomable, customZoomControls, children }: ZoompaneProps) {
   return (
     <TransformWrapper maxScale={zoomable ? 4 : 1}>
-      {zoomable && <Controls CustomZoomControls={CustomZoomControls} />}
+      {zoomable && <Controls CustomZoomControls={customZoomControls} />}
       <TransformComponent contentStyle={{ width: '100%' }} wrapperStyle={{ width: '100%' }}>
         {children}
       </TransformComponent>
@@ -26,9 +26,10 @@ function Controls({ CustomZoomControls }: { CustomZoomControls?: CustomZoomContr
   return (
     <div className="react-denmark-map-zoom-controls-wrapper">
       {CustomZoomControls ? (
+        /* We use an empty callback to avoid accidently calling `zoomIn` or `zoomOut` with arguments. */
         <CustomZoomControls onZoomIn={() => zoomIn()} onZoomOut={() => zoomOut()} />
       ) : (
-        <div className="react-denmark-map-zoom-controls">
+        <div id="react-denmark-map-zoom-controls" className="react-denmark-map-zoom-controls">
           <button onClick={() => zoomIn()}>+</button>
           <button onClick={() => zoomOut()}>–</button>
         </div>


### PR DESCRIPTION
### Proposed changes

Renamed `CustomZoomControls` to `customZoomControls`. This is because for the `customTooltip` prop, we also want to be able to pass a function returning a JSX element in addition to a React component. But it would be strange if you were to have one uppercase prop and a lowercase prop despite the fact that both were React components. Also added an id for the default custom zoom controls.

### How to test

1. Verify that passing custom zoom controls via the `customZoomControls` prop still works.