### PR TITLE
Enable passing a React component to customtooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Zoom functionality. Added the ability to zoom in and out of the map. Zoom buttons appear in the top-right hand corner by default.
-- Prop: `customZoomControls`. Pass a React component to render your own zoom-in and zoom-out buttons.
+- Prop: `customZoomControls`. Pass a functional React component to render your own zoom-in and zoom-out buttons.
 - Prop: `zoomable`. Whether to have the map be zoomable and subsequently if zoom controls should be rendered.
 - Added JSDoc comments to all props.
 - Added English terms for regions.
@@ -22,11 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed path definitions for each area in all renditions of the map, resulting in a ~30% decrease in the overall SVG size.
+- Changed the definition of the `customTooltip` prop to allow passing a React component by having the first and only parameter by an object (props) containing `area`.
 - Changed the name of fields in the area types as follows:
   - `en_name` -> `asciiName`
   - `display_name` -> `displayName`
   - `en_term` -> `enTerm`
 - Improved typing by providing explicit constant values for fields in each area.
+- Removed several `data-` attributes from the individual path elements and replaced it with a single one called `data-area-id` which is the `id` property on the rendered area object.
 - Updated the documentation to account for the new changes.
 - Updated dev dependencies.
 - Started using Turborepo for seperation of packages and apps.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,23 +1,42 @@
 # Migration guide
 
-This is a migration guide to walk you through the process of upgrading to react-denmark-map 2.0.
+This is a migration guide to walk you through the process of upgrading to react-denmark-map 2.0 from version 1.
 
 ### New features
 
 1. **Zooming**. Zoom controls now appear in the top-right hand corner of every rendition of the map which allows users to zoom in and out. You can disable this zooming or choose to customize it by passing a component as a prop.
-2. **Memoization**. Memoized all map renditions, meaning that you may be able to get a slight performance boost if the component rerenders frequently and you memoize props.
-3. **Better intellisense**. The fields in the type of areas in each rendition of the map are now explicit constants. For example, the `name` property on the `MunicipalityType` has the type `norddjurs | syddjurs | koebenhavn ...` instead of just `string`. Moreover, new JSDoc strings have been added for each prop.
+2. **Memoization**. All map renditions are now memoized, meaning that you may be able to get a slight performance boost if your parent component rerenders frequently and you memoize props.
+3. **Better intellisense**. The fields in the type of areas in each rendition of the map are now explicit constants. For example, the `name` property on the `MunicipalityType` has the type `'norddjurs' | 'syddjurs' | 'koebenhavn' ...` instead of just `string`. Moreover, new JSDoc strings have been added for each prop.
 
 Finally, all map SVG's are now ~30% smaller which should improve load times and rendering performance 🏎️
 
 ### Breaking changes
 
-1. **Positioning**. If you used the `className` or `style` properties to adjust the position of the map, you should instead wrap `<Map />` in a seperate element and position that. This was always the recommended approach but the ability to zoom breaks positioning using this method.
-2. **Viewbox**. All maps now have the same SVG viewbox dimensions of 1000 x 1215 so you should use these dimensions to customize the viewbox.
-3. **Renamed area fields**. Some keys in the area object have been renamed. These are specifically:
+1. **Tooltip type**. Changed the type of `customTooltip` to be a React component instead of a regular function to allow for greater abstraction. Below is an example of how it's used now.
+
+   ```jsx
+   import { Municipalities } from 'react-denmark-map'
+
+   const CustomTooltip = ({ area }) => {
+     return (
+       <div className="tooltip">
+         <p>Name: {area.displayName}</p>
+         <p>Municipality code: {area.code}</p>
+       </div>
+     )
+   }
+
+   const App = () => <Municipalities customTooltip={CustomTooltip} />
+   ```
+
+   You can otherwise just destructure the first parameter, `area`, if you want to avoid the slight hassle of converting it to a React component.
+
+2. **Renamed area fields**. Some keys in the area object have been renamed. These are specifically:
    - `en_name` -> `asciiName`
    - `display_name` -> `displayName`
    - `en_term` -> `enTerm`
-4. **Alt positions**. Removed all `altPosition-` props. These props rendered some islands closer to the mainland.
+3. **Positioning**. If you used the `className` or `style` properties to adjust the position of the map, you should instead wrap `<Map />` in a seperate element and position that. This was always the recommended approach but the ability to zoom breaks positioning using this method.
+4. **Viewbox**. All maps now have the same SVG viewbox dimensions of 1000 x 1215 so you should use these dimensions to customize the viewbox.
+5. **Alt positions**. Removed all `altPosition-` props. These props rendered some islands closer to the mainland.
 
 You can find more information about the changes by reading the updated documentation. Thank you for using react-denmark-map! 🇩🇰

--- a/README.md
+++ b/README.md
@@ -121,18 +121,16 @@ Instead of municipalities, these areas could also be each region or island, depe
 ```jsx
 import { Municipalities } from 'react-denmark-map'
 
-const App = () => {
-  const customTooltip = (municipality) => {
-    return (
-      <div className="tooltip">
-        <p>Name: {municipality.displayName}</p>
-        <p>Municipality code: {municipality.code}</p>
-      </div>
-    )
-  }
-
-  return <Municipalities customTooltip={customTooltip} />
+const CustomTooltip = ({ area }) => {
+  return (
+    <div className="tooltip">
+      <p>Name: {area.displayName}</p>
+      <p>Municipality code: {area.code}</p>
+    </div>
+  )
 }
+
+const App = () => <Municipalities customTooltip={CustomTooltip} />
 ```
 
 You can easily display external data about the area on the tooltip. In this example, `id` is the name of the municipality and `population` is data about the area, where we want to display data about the population of the area in the tooltip.
@@ -148,23 +146,21 @@ const data = [
   // ...
 ]
 
-const App = () => {
-  const customTooltip = (municipality) => {
-    const result = data.find((item) => item.id === municipality.name)
+const CustomTooltip = ({ area }) => {
+  const result = data.find((item) => item.id === area.name)
 
-    return (
-      <div>
-        <p>{municipality.displayName}</p>
-        <p>Population: {result?.population ? result.population : 'N/A'}</p>
-      </div>
-    )
-  }
-
-  return <Municipalities customTooltip={customTooltip} />
+  return (
+    <div>
+      <p>{area.displayName}</p>
+      <p>Population: {result?.population ? result.population : 'N/A'}</p>
+    </div>
+  )
 }
+
+const App = () => <Municipalities customTooltip={CustomTooltip} />
 ```
 
-The first parameter / the area parameter of the `customTooltip` function (here named `municipality`) contains several fields that can be used to identify the correct area. See "API" for full reference.
+The `area` prop of the `customTooltip` component contains several fields that can be used to identify the correct area. See "API" for full reference.
 
 Disable the tooltip by passing `showTooltip={false}` as a prop.
 
@@ -233,9 +229,7 @@ const CustomZoomControls = ({ onZoomIn, onZoomOut }) => (
   </div>
 )
 
-const App = () => {
-  return <Municipalities customZoomControls={CustomZoomControls} />
-}
+const App = () => <Municipalities customZoomControls={CustomZoomControls} />
 ```
 
 Pass the prop `zoomable={false}` to disable zooming (and thus not render zoom controls).
@@ -286,6 +280,10 @@ You may also want to apply types to function arguments i.e. when writing the fun
 ```jsx
 import { Municipalities, MunicipalityType } from 'react-denmark-map'
 
+const CustomTooltip = ({ area }: { area: MunicipalityType }) => (
+  // ...
+)
+
 const App = () => {
   const customizeMunicipalities = (municipality: MunicipalityType) => {
     // ...
@@ -295,7 +293,7 @@ const App = () => {
 }
 ```
 
-All props that accept a function as an argument have the same type in that component, so the same type can be applied to the parameter used in `customTooltip`, `onClick`, and `onHover`.
+All props that accept a function as an argument have the same type in that component, so the same type can be applied to the parameter used in `onClick`, `onHover`, as well as for the `area` prop in `customTooltip`.
 
 Different components have different types for the area parameter. The `Regions` component, for example, exports a `RegionsType` that can be used in the same way as shown above. See "API - Types" for the full reference of area types.
 
@@ -348,8 +346,8 @@ React Denmark Map exports several components, each being a map of Denmark with d
 | `laesoeAltPosition`   | Whether to render Læsø slightly closer to Jutland in the `Municipalities` component.                    | boolean                                                                       | false                                          |
 | `anholtAltPosition`   | Whether to render Anholt closer to Jutland in the `Municipalities` component.                           | boolean                                                                       | false                                          |
 | `zoomable`            | Whether you should be able to zoom on the map.                                                          | boolean                                                                       | true                                           |
-| `customZoomControls`  | A React component for custom zoom controls.                                                             | ComponentType<{ onZoomIn(): void; onZoomOut(): void }>                        |                                                |
-| `customTooltip`       | A function that returns a custom tooltip.                                                               | (area: AreaType<sup>\*\*\*</sup>) => ReactNode                                |                                                |
+| `customZoomControls`  | A functional component that returns custom zoom controls. Rendered top-right.                           | (props: { onZoomIn(): void; onZoomOut(): void }) => ReactNode                 |                                                |
+| `customTooltip`       | A functional component that returns a custom tooltip.                                                   | (props: { area: AreaType<sup>\*\*\*</sup> }) => ReactNode                     |                                                |
 | `customizeAreas`      | A function that is invoked for every area and returns an object to style the area.                      | (area: AreaType) => { className?: string, style? CSSProperties } \| undefined |                                                |
 | `filterAreas`         | A function that is invoked for every area that avoids rendering the area if the function returns false. | (area: AreaType) => boolean                                                   |                                                |
 | `onClick`             | A function that is invoked when an area is clicked.                                                     | (area: AreaType) => void                                                      |                                                |

--- a/apps/demo/components/examples/MunicipalitiesExample.tsx
+++ b/apps/demo/components/examples/MunicipalitiesExample.tsx
@@ -1,5 +1,16 @@
 import { Municipalities, MunicipalityType } from 'react-denmark-map'
 
+const CustomTooltip = ({ area }: { area: MunicipalityType }) => {
+  const result = municipalityData.find((item) => item.id === area.name)
+
+  return (
+    <div className="bg-white rounded p-1 text-sm shadow-lg border">
+      <p className="font-bold">{area.displayName}</p>
+      <p>{`Population: ${result?.population ? result.population.toLocaleString('en') : 'N/A'}`}</p>
+    </div>
+  )
+}
+
 export default function MunicipalitiesExample() {
   const customizeMunicipalities = (municipality: MunicipalityType) => {
     const result = municipalityData.find((item) => item.id === municipality.name)
@@ -13,24 +24,11 @@ export default function MunicipalitiesExample() {
     }
   }
 
-  const customTooltip = (municipality: MunicipalityType) => {
-    const result = municipalityData.find((item) => item.id === municipality.name)
-
-    return (
-      <div className="bg-white rounded p-1 text-sm shadow-lg border">
-        <p className="font-bold">{municipality.displayName}</p>
-        <p>{`Population: ${
-          result?.population ? result.population.toLocaleString('en') : 'N/A'
-        }`}</p>
-      </div>
-    )
-  }
-
   return (
     <div className="max-w-2xl mx-auto">
       <Municipalities
         className="p-2 sm:p-8"
-        customTooltip={customTooltip}
+        customTooltip={CustomTooltip}
         customizeAreas={customizeMunicipalities}
       />
     </div>

--- a/apps/demo/utils/descriptions.ts
+++ b/apps/demo/utils/descriptions.ts
@@ -20,14 +20,25 @@ const App = () => {
 
   return (
     <Municipalities
-      customTooltip={customTooltip}
+      customTooltip={CustomTooltip}
       customizeAreas={customizeMunicipalities}
     />
   )
 }`,
       full: `import { Municipalities } from 'react-denmark-map'
-  
+
 const municipalityData = [{ ... }]
+  
+const CustomTooltip = ({ area }: { area: MunicipalityType }) => {
+  const result = municipalityData.find((item) => item.id === area.name)
+
+  return (
+    <div className="bg-white rounded p-1 text-sm shadow-lg border">
+      <p className="font-bold">{area.displayName}</p>
+      <p>{\`Population: \${result?.population ? result.population.toLocaleString('en') : 'N/A'}\`}</p>
+    </div>
+  )
+}
 
 const App = () => {
   const customizeMunicipalities = (municipality) => {
@@ -42,20 +53,9 @@ const App = () => {
     }
   }
 
-  const customTooltip = (municipality) => {
-    const result = municipalityData.find((item) => item.id === municipality.name)
-
-    return (
-      <div>
-        <p>{municipality.displayName}</p>
-        <p>{\`Population: \${result?.population ?? 'N/A'}\`}</p>
-      </div>
-    )
-  }
-
   return (
     <Municipalities
-      customTooltip={customTooltip}
+      customTooltip={CustomTooltip}
       customizeAreas={customizeMunicipalities}
     />
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -4112,6 +4112,32 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.0.tgz",
+      "integrity": "sha512-+1ge/xmaJpm1KVBuIH38Z94zj9fBD+hp+/5WLaHgyY8XLq1ibxk/zj6dTXaqM2cAbYKq8jYlhHd6k05If1W5xA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.0.tgz",
+      "integrity": "sha512-im6hUEyQ7ZfoZdNvtwgEJvBWZYauC9KVKq1w58LG2Zfz6zMd8gRrbN+xCVoqA2hv/v6fm9lp5LFGJ3za8EQH3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.9.0",
       "cpu": [
@@ -4122,6 +4148,135 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.0.tgz",
+      "integrity": "sha512-8FvEl3w2ExmpcOmX5RJD0yqXcVSOqAJJUJ29Lca29Ik+3zPS1yFimr2fr5JSZ4Z5gt8/d7WqycpgkX9nocijSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.0.tgz",
+      "integrity": "sha512-lHoKYaRwd4gge+IpqJHCY+8Vc3hhdJfU6ukFnnrJasEBUvVlydP8PuwndbWfGkdgSvZhHfSEw6urrlBj0TSSfg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.0.tgz",
+      "integrity": "sha512-JbEPfhndYeWHfOSeh4DOFvNXrj7ls9S/2omijVsao+LBPTPayT1uKcK3dHW3MwDJ7KO11t9m2cVTqXnTKpeaiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.0.tgz",
+      "integrity": "sha512-ahqcSXLlcV2XUBM3/f/C6cRoh7NxYA/W7Yzuv4bDU1YscTFw7ay4LmD7l6OS8EMhTNvcrWGkEettL1Bhjf+B+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.0.tgz",
+      "integrity": "sha512-uwvOYNtLw8gVtrExKhdFsYHA/kotURUmZYlinH2VcQxNCQJeJXnkmWgw2hI9Xgzhgu7J9QvWiq9TtTVwWMDa+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
+      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.0.tgz",
+      "integrity": "sha512-VFAC1RDRSbU3iOF98X42KaVicAfKf0m0OvIu8dbnqhTe26Kh6Ym9JrDulz7Hbk7/9zGc41JkV02g+p3BivOdAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.0.tgz",
+      "integrity": "sha512-9jPgMvTKXARz4inw6jezMLA2ihDBvgIU9Ml01hjdVpOcMKyxFBJrn83KVQINnbeqDv0+HdO1c09hgZ8N0s820Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.0.tgz",
+      "integrity": "sha512-WE4pT2kTXQN2bAv40Uog0AsV7/s9nT9HBWXAou8+++MBCnY51QS02KYtm6dQxxosKi1VIz/wZIrTQO5UP2EW+Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.0.tgz",
+      "integrity": "sha512-aPP5Q5AqNGuT0tnuEkK/g4mnt3ZhheiXrDIiSVIHN9mcN21OyXDVbEMqmXPE7e2OplNLDkcvV+ZoGJa2ZImFgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -17935,6 +18090,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.0.tgz",
+      "integrity": "sha512-m6pkSwcZZD2LCFHZX/zW2aLIISyzWLU3hrLLzQKMI12+OLEzgruTovAxY5sCZJkipklaZqPy/2bEEBNjp+Y7xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -20516,6 +20684,9 @@
         "storybook": "^7.6.4",
         "tslib": "^2.6.2",
         "typescript": "^5.3.3"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.12.0"
       },
       "peerDependencies": {
         "react": "17.x || 18.x",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,5 +87,8 @@
   "type": "module",
   "dependencies": {
     "react-zoom-pan-pinch": "^3.3.0"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "^4.12.0"
   }
 }

--- a/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
+++ b/packages/core/src/components/areas/municipalities/Municipalities.stories.tsx
@@ -301,6 +301,25 @@ const MunicipalitiesInRegionsTemplate: StoryFn<typeof Municipalities> = (args) =
 
 export const WithHighlightedRegions = MunicipalitiesInRegionsTemplate.bind({})
 
+const CustomTooltip = ({ area }: { area: MunicipalityType }) => {
+  const result = mockMunicipalityData.find((item) => item.id === area.name)
+
+  return (
+    <div
+      style={{
+        color: 'white',
+        backgroundColor: '#101e2b',
+        borderRadius: '4px',
+        boxShadow: '0 0 8px rgba(0, 0, 0, 0.2)',
+        padding: '6px 12px'
+      }}
+    >
+      <p style={{ fontWeight: 'bold', margin: '0px' }}>{area.displayName}</p>
+      <p style={{ margin: '2px 0 0' }}>Average: {result?.average ? result.average : 'N/A'}</p>
+    </div>
+  )
+}
+
 export const WithCustomTooltip: Story = {
   args: {
     customizeAreas: (municipality) => {
@@ -314,24 +333,7 @@ export const WithCustomTooltip: Story = {
         }
       }
     },
-    customTooltip: (municipality) => {
-      const result = mockMunicipalityData.find((item) => item.id === municipality.name)
-
-      return (
-        <div
-          style={{
-            color: 'white',
-            backgroundColor: '#101e2b',
-            borderRadius: '4px',
-            boxShadow: '0 0 8px rgba(0, 0, 0, 0.2)',
-            padding: '6px 12px'
-          }}
-        >
-          <p style={{ fontWeight: 'bold', margin: '0px' }}>{municipality.displayName}</p>
-          <p style={{ margin: '2px 0 0' }}>Average: {result?.average ? result.average : 'N/A'}</p>
-        </div>
-      )
-    }
+    customTooltip: CustomTooltip
   }
 }
 

--- a/packages/core/src/components/map/Map.test.tsx
+++ b/packages/core/src/components/map/Map.test.tsx
@@ -258,11 +258,11 @@ describe('Map', () => {
 
     describe('customTooltip', () => {
       it('should render the custom tooltip when hovering', () => {
-        const customTooltip = (municipality: MunicipalityType) => (
-          <div>{municipality.displayName}</div>
+        const CustomTooltip = ({ area }: { area: MunicipalityType }) => (
+          <div>{area.displayName}</div>
         )
 
-        const { container } = render(<Municipalities customTooltip={customTooltip} />)
+        const { container } = render(<Municipalities customTooltip={CustomTooltip} />)
 
         const municipality = container.querySelector('[data-area-id="langeland"]')
         if (!municipality) throw new Error('Municipality not found')

--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ComponentType, MouseEvent, ReactNode, memo, useRef } from 'react'
+import { CSSProperties, MouseEvent, ReactNode, memo, useRef } from 'react'
 import Tooltip, { TooltipMethods } from './Tooltip'
 import Zoompane from './Zoompane'
 import { RegionType } from '../areas/regions'
@@ -79,26 +79,22 @@ export interface MapProps<Type extends Area> {
    * )
    * ```
    */
-  customZoomControls?: ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
+  customZoomControls?: (props: { onZoomIn(): void; onZoomOut(): void }) => ReactNode
   /** Component for displaying a custom tooltip.
    *
    * @param area The area that the tooltip is being displayed for.
    * @example
    * ```jsx
-   * const App = () => {
-   *   const customTooltip = (area) => (
-   *    <div>
-   *      <p>{area.displayName}</p>
-   *    </div>
-   *   )
+   * const CustomTooltip = ({ area }) => (
+   *   <div>
+   *     <p>{area.displayName}</p>
+   *   </div>
+   * )
    *
-   *   return (
-   *    <Municipalities customTooltip={customTooltip} />
-   *   )
-   * }
+   * const App = () => <Municipalities customTooltip={CustomTooltip} />
    * ```
    */
-  customTooltip?: (area: Type) => ReactNode
+  customTooltip?: (props: { area: Type }) => ReactNode
   /** Custom event handler for handling clicks on a particular area.
    *
    * @param area The area that was clicked.
@@ -306,7 +302,7 @@ const Map = <Type extends Area>(props: PrivateMapProps<Type>) => {
       <Tooltip
         show={typeof showTooltip === 'undefined' ? true : showTooltip}
         areas={areas}
-        customTooltip={customTooltip as (area: Area) => ReactNode}
+        customTooltip={customTooltip as (props: { area: Area }) => ReactNode}
         ref={tooltip}
       />
       <Zoompane zoomable={zoomable as boolean} customZoomControls={customZoomControls}>

--- a/packages/core/src/components/map/Tooltip.tsx
+++ b/packages/core/src/components/map/Tooltip.tsx
@@ -13,7 +13,7 @@ import { Area } from './Map'
 interface TooltipProps<Type> {
   show: boolean
   areas: readonly Type[]
-  customTooltip?: (area: Type) => ReactNode
+  customTooltip?: (props: { area: Type }) => ReactNode
 }
 
 export type TooltipMethods = {
@@ -83,7 +83,7 @@ function Tooltip<Type extends Area>(
     }))
   }
 
-  const defaultTooltip = (area: Area) => {
+  const defaultTooltip = ({ area }: { area: Area }) => {
     return (
       <div id="react-denmark-map-tooltip" className="react-denmark-map-tooltip">
         <p>{area.displayName}</p>
@@ -95,7 +95,7 @@ function Tooltip<Type extends Area>(
 
   return (
     <div role="tooltip" id="react-denmark-map-tooltip-wrapper" style={tooltipStyle}>
-      {hoveredArea && tooltip(hoveredArea)}
+      {hoveredArea && tooltip({ area: hoveredArea })}
     </div>
   )
 }

--- a/packages/core/src/components/map/Zoompane.tsx
+++ b/packages/core/src/components/map/Zoompane.tsx
@@ -1,7 +1,7 @@
-import { ComponentType, ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { TransformComponent, TransformWrapper, useControls } from 'react-zoom-pan-pinch'
 
-type CustomZoomControls = ComponentType<{ onZoomIn(): void; onZoomOut(): void }>
+type CustomZoomControls = (props: { onZoomIn(): void; onZoomOut(): void }) => ReactNode
 
 type ZoompaneProps = {
   zoomable: boolean


### PR DESCRIPTION
### Proposed changes

Enabled passing a React component to `customTooltip` by changing the type and functionality of the function. Also added an optional dependency to enable building the demo project in the CI.

### How to test

1. In Storybook, verify that passing `customTooltip` with a React component works.