### PR TITLE
Fix map not being displayed in demo on iOS

### DIFF
--- a/packages/core/src/components/map/Map.tsx
+++ b/packages/core/src/components/map/Map.tsx
@@ -281,7 +281,8 @@ const Map = <Type extends Area>(props: PrivateMapProps<Type>) => {
       style={{
         position: 'relative',
         maxWidth: '1180px',
-        margin: 0
+        margin: 0,
+        minHeight: 'fit-content'
       }}
     >
       <Tooltip


### PR DESCRIPTION
### Proposed changes

Fixed the map not being displayed in the demo on iOS.

### How to test

1. Go to the preview deployment of the demo on iOS and verify that the map it is displayed.