### PR TITLE
Fix Læsø not being displayed in demo

### DIFF
--- a/apps/demo/components/examples/MunicipalitiesExample.tsx
+++ b/apps/demo/components/examples/MunicipalitiesExample.tsx
@@ -19,7 +19,7 @@ export default function MunicipalitiesExample() {
 
     return {
       style: {
-        fill: `rgba(204, 0, 0, ${result.population / 150000})`
+        fill: `rgba(204, 0, 0, ${(result.population + 20000) / 150000})`
       }
     }
   }


### PR DESCRIPTION
### Proposed changes

The island of Læsø was not displayed in the `Municipalities` example in the demo. This issue was due to the fact that the fill color of the municipality is calculated based on the population and since Læsø has a population of just ~1700, it would disappear completely.

### How to test

1. Run the demo project and verify that Læsø is visible in the `Municipalities` example.